### PR TITLE
change signature of perishables callback to include the CR and logger

### DIFF
--- a/pkg/sdk/reconciler/builder.go
+++ b/pkg/sdk/reconciler/builder.go
@@ -103,6 +103,6 @@ func updateControllerConfiguration(_ controllerutil.Object) error {
 	return nil
 }
 
-func syncPerishables() error {
+func syncPerishables(cr controllerutil.Object, logger logr.Logger) error {
 	return nil
 }

--- a/pkg/sdk/reconciler/reconciler.go
+++ b/pkg/sdk/reconciler/reconciler.go
@@ -45,7 +45,7 @@ const (
 )
 
 // PerishablesSynchronizer is expected to execute perishable resources (i.e. certificates) synchronization if required
-type PerishablesSynchronizer func() error
+type PerishablesSynchronizer func(cr controllerutil.Object, logger logr.Logger) error
 
 // ControllerConfigUpdater is expected to update controller configuration if required
 type ControllerConfigUpdater func(cr controllerutil.Object) error
@@ -322,7 +322,7 @@ func (r *Reconciler) ReconcileUpdate(logger logr.Logger, cr controllerutil.Objec
 		}
 	}
 
-	if err = r.syncPerishables(); err != nil {
+	if err = r.syncPerishables(cr, logger); err != nil {
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

I think this makes sense.  Same signature of sanityChecker.

```release-note
Change signature of perishables callback to include the CR and logger
```