### PR TITLE
Address labels not updating after upgrade

### DIFF
--- a/pkg/sdk/reconciler/reconciler.go
+++ b/pkg/sdk/reconciler/reconciler.go
@@ -782,4 +782,15 @@ func (r *Reconciler) setRecommendedLabels(cr client.Object, obj metav1.Object) {
 	for k, v := range labels {
 		sdk.SetLabel(k, v, obj)
 	}
+
+	// Actual workload templates need special care, otherwise we just update the top level labels
+	switch typedObj := obj.(type) {
+	case *appsv1.Deployment:
+		if typedObj.Spec.Template.GetLabels() == nil {
+			typedObj.Spec.Template.SetLabels(make(map[string]string))
+		}
+		for k, v := range labels {
+			typedObj.Spec.Template.GetLabels()[k] = v
+		}
+	}
 }

--- a/pkg/sdk/reconciler/reconciler_test.go
+++ b/pkg/sdk/reconciler/reconciler_test.go
@@ -682,6 +682,10 @@ var _ = Describe("Reconciler", func() {
 				storedObj, err := getObject(args.client, r)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(storedObj.GetLabels()[sdk.AppKubernetesVersionLabel]).Should(Equal(newVersion))
+				switch typedObj := storedObj.(type) {
+				case *appsv1.Deployment:
+					Expect(typedObj.Spec.Template.GetLabels()[sdk.AppKubernetesVersionLabel]).Should(Equal(newVersion))
+				}
 			}
 		})
 	})


### PR DESCRIPTION
We expect labels to be present on workloads after upgrade, but right now, they are only existing on the top level of resources
(deployment.metadata.labels but not in deployment.spec.template.metadata.labels).

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>