### PR TITLE
Aggregate failed workload conditions into CR

### DIFF
--- a/examples/sample-operator/automation/test.sh
+++ b/examples/sample-operator/automation/test.sh
@@ -33,3 +33,7 @@ make cluster-up
 make cluster-sync
 
 ./automation/execute-tests.sh
+
+# Unit tests
+cd "$(git rev-parse --show-toplevel)"
+go test -v ./...

--- a/examples/sample-operator/cluster/kubevirtci.sh
+++ b/examples/sample-operator/cluster/kubevirtci.sh
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.18'}
-export KUBEVIRTCI_VERSION=${KUBEVIRTCI_VERSION:-'463da29b9cbdcaa22daed3a8ef5c5e864f582b0b'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.24'}
+export KUBEVIRTCI_VERSION=${KUBEVIRTCI_VERSION:-'4b9b02c79acc237bc0c56201f213a854d204c088'}
+export KUBEVIRTCI_TAG=2303092154-4b9b02c
+export KUBEVIRTCI_RUNTIME=docker
 
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 

--- a/examples/sample-operator/templates/sample-operator/VERSION/operator.yaml.in
+++ b/examples/sample-operator/templates/sample-operator/VERSION/operator.yaml.in
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sampleconfigs.sample.lifecycle.kubevirt.io
@@ -10,754 +10,753 @@ spec:
     plural: sampleconfigs
     singular: sampleconfig
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SampleConfig is the Schema for the sampleconfigs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SampleConfigSpec defines the desired state of SampleConfig
-          properties:
-            infra:
-              description: Rules on which nodes controller pod(s) will be scheduled
-              properties:
-                affinity:
-                  description: affinity enables pod affinity/anti-affinity placement
-                    expanding the types of constraints that can be expressed with
-                    nodeSelector. affinity is going to be applied to the relevant
-                    kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for
-                        the pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling
-                            requirements (resource request, requiredDuringScheduling
-                            affinity expressions, etc.), compute a sum by iterating
-                            through the elements of this field and adding "weight"
-                            to the sum if the node matches the corresponding matchExpressions;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects
-                              (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key,
-                                        and an operator that relates the key and
-                                        values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators
-                                            are In, NotIn, Exists, DoesNotExist.
-                                            Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the
-                                            values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the
-                                            operator is Gt or Lt, the values array
-                                            must have a single element, which will
-                                            be interpreted as an integer. This array
-                                            is replaced during a strategic merge
-                                            patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key,
-                                        and an operator that relates the key and
-                                        values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators
-                                            are In, NotIn, Exists, DoesNotExist.
-                                            Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the
-                                            values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the
-                                            operator is Gt or Lt, the values array
-                                            must have a single element, which will
-                                            be interpreted as an integer. This array
-                                            is replaced during a strategic merge
-                                            patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the
-                                  corresponding nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from
-                            its node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term
-                                  matches no objects. The requirements of them are
-                                  ANDed. The TopologySelectorTerm type implements
-                                  a subset of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key,
-                                        and an operator that relates the key and
-                                        values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators
-                                            are In, NotIn, Exists, DoesNotExist.
-                                            Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the
-                                            values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the
-                                            operator is Gt or Lt, the values array
-                                            must have a single element, which will
-                                            be interpreted as an integer. This array
-                                            is replaced during a strategic merge
-                                            patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key,
-                                        and an operator that relates the key and
-                                        values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators
-                                            are In, NotIn, Exists, DoesNotExist.
-                                            Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the
-                                            values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the
-                                            operator is Gt or Lt, the values array
-                                            must have a single element, which will
-                                            be interpreted as an integer. This array
-                                            is replaced during a strategic merge
-                                            patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g.
-                        co-locate this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling
-                            requirements (resource request, requiredDuringScheduling
-                            affinity expressions, etc.), compute a sum by iterating
-                            through the elements of this field and adding "weight"
-                            to the sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list
-                                          of label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values,
-                                            a key, and an operator that relates
-                                            the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key
-                                                that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a
-                                                key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists
-                                                and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of
-                                                string values. If the operator is
-                                                In or NotIn, the values array must
-                                                be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values
-                                                array must be empty. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator
-                                          is "In", and the values array contains
-                                          only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the
-                                      pods matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as
-                                      running on a node whose value of the label
-                                      with key topologyKey matches that of any node
-                                      on which any of the selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the
-                                  corresponding podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements,
-                            the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located
-                              is defined as running on a node whose value of the
-                              label with key <topologyKey> matches that of any node
-                              on which a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement
-                                        is a selector that contains values, a key,
-                                        and an operator that relates the key and
-                                        values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that
-                                            the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and
-                                            DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty.
-                                            If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This
-                                            array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is
-                                      "In", and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey
-                                  matches that of any node on which any of the selected
-                                  pods is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules
-                        (e.g. avoid putting this pod in the same node, zone, etc.
-                        as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the anti-affinity expressions
-                            specified by this field, but it may choose a node that
-                            violates one or more of the expressions. The node that
-                            is most preferred is the one with the greatest sum of
-                            weights, i.e. for each node that meets all of the scheduling
-                            requirements (resource request, requiredDuringScheduling
-                            anti-affinity expressions, etc.), compute a sum by iterating
-                            through the elements of this field and adding "weight"
-                            to the sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list
-                                          of label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values,
-                                            a key, and an operator that relates
-                                            the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key
-                                                that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a
-                                                key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists
-                                                and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of
-                                                string values. If the operator is
-                                                In or NotIn, the values array must
-                                                be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values
-                                                array must be empty. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator
-                                          is "In", and the values array contains
-                                          only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the
-                                      pods matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as
-                                      running on a node whose value of the label
-                                      with key topologyKey matches that of any node
-                                      on which any of the selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the
-                                  corresponding podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified
-                            by this field are not met at scheduling time, the pod
-                            will not be scheduled onto the node. If the anti-affinity
-                            requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to a pod
-                            label update), the system may or may not try to eventually
-                            evict the pod from its node. When there are multiple
-                            elements, the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located
-                              is defined as running on a node whose value of the
-                              label with key <topologyKey> matches that of any node
-                              on which a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement
-                                        is a selector that contains values, a key,
-                                        and an operator that relates the key and
-                                        values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that
-                                            the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and
-                                            DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty.
-                                            If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This
-                                            array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is
-                                      "In", and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey
-                                  matches that of any node on which any of the selected
-                                  pods is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: 'nodeSelector is the node selector applied to the
-                                relevant kind of pods It specifies a map of key-value pairs:
-                                for the pod to be eligible to run on a node, the node must have
-                                each of the indicated key-value pairs as labels (it can have
-                                additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
-                  type: object
-                tolerations:
-                  description: tolerations is a list of tolerations applied to the
-                    relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-                    for more info. These are additional tolerations other than default
-                    ones.
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using
-                      the matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match.
-                          Empty means match all taint effects. When specified, allowed
-                          values are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to
-                          the value. Valid operators are Exists and Equal. Defaults
-                          to Equal. Exists is equivalent to wildcard for value,
-                          so that a pod can tolerate all taints of a particular
-                          category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of
-                          time the toleration (which must be of effect NoExecute,
-                          otherwise this field is ignored) tolerates the taint.
-                          By default, it is not set, which means tolerate the taint
-                          forever (do not evict). Zero and negative values will
-                          be treated as 0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-        status:
-          description: SampleConfigStatus defines the observed state of SampleConfig
-          properties:
-            conditions:
-              description: A list of current conditions of the resource
-              items:
-                description: Condition represents the state of the operator's reconciliation
-                  functionality.
-                properties:
-                  lastHeartbeatTime:
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: ConditionType is the state of the operator's reconciliation
-                      functionality.
-                    type: string
-                required:
-                  - status
-                  - type
-                type: object
-              type: array
-            observedVersion:
-              description: The observed version of the resource
-              type: string
-            operatorVersion:
-              description: The version of the resource as defined by the operator
-              type: string
-            phase:
-              description: Phase is the current phase of the deployment
-              type: string
-            targetVersion:
-              description: The desired version of the resource
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: SampleConfig is the Schema for the sampleconfigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SampleConfigSpec defines the desired state of SampleConfig
+              properties:
+                infra:
+                  description: Rules on which nodes controller pod(s) will be scheduled
+                  properties:
+                    affinity:
+                      description: affinity enables pod affinity/anti-affinity placement
+                        expanding the types of constraints that can be expressed with
+                        nodeSelector. affinity is going to be applied to the relevant
+                        kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'nodeSelector is the node selector applied to the
+                                    relevant kind of pods It specifies a map of key-value pairs:
+                                    for the pod to be eligible to run on a node, the node must have
+                                    each of the indicated key-value pairs as labels (it can have
+                                    additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                      type: object
+                    tolerations:
+                      description: tolerations is a list of tolerations applied to the
+                        relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                        for more info. These are additional tolerations other than default
+                        ones.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              description: SampleConfigStatus defines the observed state of SampleConfig
+              properties:
+                conditions:
+                  description: A list of current conditions of the resource
+                  items:
+                    description: Condition represents the state of the operator's reconciliation
+                      functionality.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType is the state of the operator's reconciliation
+                          functionality.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedVersion:
+                  description: The observed version of the resource
+                  type: string
+                operatorVersion:
+                  description: The version of the resource as defined by the operator
+                  type: string
+                phase:
+                  description: Phase is the current phase of the deployment
+                  type: string
+                targetVersion:
+                  description: The desired version of the resource
+                  type: string
+              type: object
+          type: object
 ---
 apiVersion: v1
 kind: Namespace

--- a/pkg/sdk/util.go
+++ b/pkg/sdk/util.go
@@ -170,6 +170,28 @@ func CheckDeploymentReady(deployment *appsv1.Deployment) bool {
 	return true
 }
 
+func CheckDeploymentRequiresIntervention(deployment *appsv1.Deployment) bool {
+	var progressing, available bool
+	if cond := GetDeploymentCondition(deployment.Status, appsv1.DeploymentAvailable); cond != nil && cond.Status == v1.ConditionTrue {
+		available = true
+	}
+	if cond := GetDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing); cond != nil && cond.Status == v1.ConditionTrue {
+		progressing = true
+	}
+
+	return !progressing && !available
+}
+
+func GetDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
 func NewDefaultInstance(obj client.Object) client.Object {
 	typ := reflect.ValueOf(obj).Elem().Type()
 	return reflect.New(typ).Interface().(client.Object)


### PR DESCRIPTION
Currently, we just dangle in `Deploying` phase when things go badly, although
the deployment conditions API provides more information such as `Progressing=false`
that we can use to better capture the status of install.

```release-note
Aggregate failed workload conditions into CR
```