### PR TITLE
Avoid hotloop over empty clusterrole rules

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    reviewers:
+      - code-reviewers
+    approvers:
+      - approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  approvers:
+      - awels
+      - mhenriks
+      - akalenyu
+  code-reviewers:
+      - awels
+      - mhenriks
+      - akalenyu

--- a/pkg/sdk/resources/rbac.go
+++ b/pkg/sdk/resources/rbac.go
@@ -52,7 +52,7 @@ func (b *ResourceBuilder) CreateRoleBinding(name, roleRef, serviceAccount, servi
 
 // CreateRole creates role
 func (b *ResourceBuilder) CreateRole(name string, rules []rbacv1.PolicyRule) *rbacv1.Role {
-	return &rbacv1.Role{
+	role := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "Role",
@@ -61,8 +61,12 @@ func (b *ResourceBuilder) CreateRole(name string, rules []rbacv1.PolicyRule) *rb
 			Name:   name,
 			Labels: b.WithCommonLabels(nil),
 		},
-		Rules: rules,
 	}
+	if len(rules) > 0 {
+		// avoid hotloop over empty rules/nil
+		role.Rules = rules
+	}
+	return role
 }
 
 // CreateClusterRoleBinding creates cluster role binding
@@ -132,7 +136,7 @@ func CreateClusterRoleBinding(name, roleRef, serviceAccount, serviceAccountNames
 
 // CreateClusterRole creates a cluster role
 func CreateClusterRole(name string, rules []rbacv1.PolicyRule, labels map[string]string) *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
+	clusterRole := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRole",
@@ -141,6 +145,10 @@ func CreateClusterRole(name string, rules []rbacv1.PolicyRule, labels map[string
 			Name:   name,
 			Labels: labels,
 		},
-		Rules: rules,
 	}
+	if len(rules) > 0 {
+		// avoid hotloop over empty rules/nil
+		clusterRole.Rules = rules
+	}
+	return clusterRole
 }

--- a/pkg/sdk/resources/rbac_test.go
+++ b/pkg/sdk/resources/rbac_test.go
@@ -1,0 +1,30 @@
+package resources
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+var _ = Describe("RBAC Resources", func() {
+	var builder ResourceBuilder
+
+	BeforeEach(func() {
+		builder = NewResourceBuilder(
+			map[string]string{"common": "label"},
+			map[string]string{"operator": "label"},
+		)
+	})
+
+	It("should treat empty rules as nil for Role", func() {
+		role := builder.CreateRole("test-role", []rbacv1.PolicyRule{})
+		Expect(role.Rules).To(BeNil())
+	})
+
+	It("should treat empty rules as nil for ClusterRole", func() {
+		labels := map[string]string{"test": "label"}
+		clusterRole := CreateClusterRole("test-clusterrole", []rbacv1.PolicyRule{}, labels)
+		Expect(clusterRole.Rules).To(BeNil())
+	})
+})

--- a/pkg/sdk/resources/resources_suite_test.go
+++ b/pkg/sdk/resources/resources_suite_test.go
@@ -1,0 +1,13 @@
+package resources
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resources Suite")
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For an empty list, we get in a hotloop over it being persisted with nil
```
2026-01-14T04:29:20Z	INFO	DIFF	{"controller": "migcontroller-controller", "object": {"name":"migcontroller-kubevirt-hyperconverged","namespace":"openshift-cnv"}, "namespace": "openshift-cnv", "name": "migcontroller-kubevirt-hyperconverged", "reconcileID": "d5cabc29-c944-4271-8b88-b5284c55c266", "obj": {"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "ClusterRole", "name": "migrations.kubevirt.io:admin"}, "patch": "[{\"op\":\"add\",\"path\":\"/rules\",\"value\":[]}]"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: event spam over rbac update
```
