### PR TITLE
Use separate maps for selector/regular labels

### DIFF
--- a/pkg/sdk/resources/resources.go
+++ b/pkg/sdk/resources/resources.go
@@ -37,8 +37,9 @@ func (b *ResourceBuilder) WithOperatorLabels(labels map[string]string) map[strin
 
 // CreateOperatorDeployment creates deployment
 func (b *ResourceBuilder) CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount string, numReplicas int32, podSpec corev1.PodSpec) *appsv1.Deployment {
-	labels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
-	return CreateDeployment(name, namespace, labels, labels, numReplicas, podSpec, serviceAccount, nil)
+	selectorLabels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
+	podLabels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
+	return CreateDeployment(name, namespace, selectorLabels, podLabels, numReplicas, podSpec, serviceAccount, nil)
 }
 
 // CreateDeployment creates deployment

--- a/pkg/sdk/resources/resources_suite_test.go
+++ b/pkg/sdk/resources/resources_suite_test.go
@@ -1,0 +1,13 @@
+package resources
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resources Suite")
+}

--- a/pkg/sdk/resources/resources_test.go
+++ b/pkg/sdk/resources/resources_test.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("CreateOperatorDeployment", func() {
+	It("should use distinct maps for selector and pod template labels", func() {
+		builder := NewResourceBuilder(
+			map[string]string{"common": "label"},
+			map[string]string{"operator": "label"},
+		)
+
+		deployment := builder.CreateOperatorDeployment(
+			"test-operator", "test-ns",
+			"app", "my-operator",
+			"sa", 1, corev1.PodSpec{},
+		)
+
+		selectorLabels := deployment.Spec.Selector.MatchLabels
+		podLabels := deployment.Spec.Template.Labels
+
+		Expect(selectorLabels).To(Equal(podLabels))
+
+		podLabels["extra-pod-label"] = "should-not-leak"
+
+		Expect(selectorLabels).ToNot(HaveKey("extra-pod-label"))
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This bit us at https://github.com/kubevirt/kubevirt-migration-operator/pull/85

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
